### PR TITLE
Update for Blender 3.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ def repeat_grid(geometry: Geometry, width: Int, height: Int):
     g = grid(
         size_x=width, size_y=height,
         vertices_x=width, vertices_y=height
-    ).mesh_to_points()
+    ).mesh.mesh_to_points()
     return g.instance_on_points(instance=geometry)
 ```
 


### PR DESCRIPTION
Closes #16 

This simplifies some of the node discovery logic. This leads to more nodes seeping in from other areas of Blender, but so far I have not found a better way of identifying the available Geometry Nodes.

This wouldn't be a problem if all Geometry Nodes were subclasses of `bpy.types.GeometryNode`. But some simple nodes are taken from the shader editor (among other places), like `ShaderNodeVectorMath`.