### PR TITLE
Refactor simulation API to use `simulation_zone` decorator

### DIFF
--- a/api/node_mapper.py
+++ b/api/node_mapper.py
@@ -13,6 +13,21 @@ class OutputsList(dict):
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 
+def set_or_create_link(x, node_input):
+    if issubclass(type(x), Type):
+        State.current_node_tree.links.new(x._socket, node_input)
+    else:
+        def link_constant():
+            constant = Type(value=x)
+            State.current_node_tree.links.new(constant._socket, node_input)
+        if node_input.hide_value:
+            link_constant()
+        else:
+            try:
+                node_input.default_value = x
+            except:
+                link_constant()
+
 def build_node(node_type):
     def build(_primary_arg=None, **kwargs):
         for k, v in kwargs.copy().items():
@@ -40,20 +55,6 @@ def build_node(node_type):
                 if node_input2.name.lower().replace(' ', '_') == argname and node_input2.type == node_input.type:
                     all_with_name.append(node_input2)
             if argname in kwargs:
-                def set_or_create_link(x, node_input):
-                    if issubclass(type(x), Type):
-                        State.current_node_tree.links.new(x._socket, node_input)
-                    else:
-                        def link_constant():
-                            constant = Type(value=x)
-                            State.current_node_tree.links.new(constant._socket, node_input)
-                        if node_input.hide_value:
-                            link_constant()
-                        else:
-                            try:
-                                node_input.default_value = x
-                            except:
-                                link_constant()
                 value = kwargs[argname]
                 if isinstance(value, enum.Enum):
                     value = value.value

--- a/api/types.py
+++ b/api/types.py
@@ -20,6 +20,15 @@ def socket_type_to_data_type(socket_type):
         case _:
             return socket_type
 
+def socket_class_to_data_type(socket_class_name):
+    match socket_class_name:
+        case 'NodeSocketGeometry':
+            return 'GEOMETRY'
+        case 'NodeSocketFloat':
+            return 'FLOAT'
+        case _:
+            return socket_class_name
+
 # The base class all exposed socket types conform to.
 class _TypeMeta(type):
     def __getitem__(self, args):
@@ -217,6 +226,8 @@ class Type(metaclass=_TypeMeta):
         return self.transfer_attribute(data_type=data_type, attribute=attribute, **kwargs)
     
     def __getitem__(self, subscript):
+        if self._socket.type == 'VECTOR' and isinstance(subscript, int):
+            return self._get_xyz_component(subscript)
         if isinstance(subscript, tuple):
             accessor = subscript[0]
             args = subscript[1:]

--- a/book/src/api/advanced-scripting/simulation.md
+++ b/book/src/api/advanced-scripting/simulation.md
@@ -1,26 +1,22 @@
 # Simulation
 
-> This API is subject to change as future builds of Blender with simulation nodes are released.
-
-The `geometry-nodes-simulation` branch of Blender 3.5 includes support for "simulation nodes".
+Blender 3.6 includes simulation nodes.
 
 Using a *Simulation Input* and *Simulation Output* node, you can create effects that change over time.
 
-As a convenience, the `@simulation` decorator is provided to make simulation node blocks easier to create.
+As a convenience, the `@simulation_zone` decorator is provided to make simulation node blocks easier to create.
 
 ```python
-@simulation
-def move_over_time(
-    geometry: Geometry, # the first input must be `Geometry`
-    speed: Float,
-    dt: SimulationInput.DeltaTime, # Automatically passes the delta time on any argument annotated with `SimulationInput.DeltaTime`.
-    elapsed: SimulationInput.ElapsedTime, # Automatically passes the elapsed time
-) -> Geometry:
-    return geometry.set_position(
-        offset=combine_xyz(x=speed)
-    )
+from geometry_script import *
+
+@tree
+def test_sim(geometry: Geometry):
+    @simulation_zone
+    def my_sim(delta_time, geometry: Geometry, value: Float):
+        return (geometry, value)
+    return my_sim(geometry, 0.26).value
 ```
 
-Every frame the argument `geometry` will be set to the geometry from the previous frame. This allows the offset to accumulate over time.
-
-The `SimulationInput.DeltaTime`/`SimulationInput.ElapsedTime` types mark arguments that should be given the outputs from the *Simulation Input* node.
+The first argument should always be `delta_time`. Any other arguments must also be returned as a tuple with their modified values.
+Each frame, the result from the previous frame is passed into the zone's inputs.
+The initial call to `my_sim` in `test_sim` provides the initial values for the simulation.


### PR DESCRIPTION
Closes #24 

A new decorator called `@simulation_zone` will handle creating/pairing simulation input/output nodes together.

The simulation can contain any number of inputs. When called from the outside, the arguments passed are used as initial values to the simulation input.

Each zone should return a tuple with the same order as its arguments. These will be passed back into the zone on the next frame.

```python
from geometry_script import *

@tree
def test_sim(geometry: Geometry):
    @simulation_zone
    def my_sim(delta_time, geometry: Geometry, value: Float):
        return (geometry, value)
    return my_sim(geometry, 0.26).value
```