### PR TITLE
Improve efficiency of arranging nodes

### DIFF
--- a/api/arrange.py
+++ b/api/arrange.py
@@ -23,8 +23,10 @@ def _arrange(node_tree, padding: typing.Tuple[float, float] = (50, 25)):
         return topo_order
     
     graph = { node:set() for node in node_tree.nodes }
+    node_input_link_count = { i:0  for node in node_tree.nodes for i in node.inputs }
     for link in node_tree.links:
         graph[link.from_node].add(link.to_node)
+        node_input_link_count[link.to_socket] += 1
     sorted_nodes = topo_sort(graph)
 
     column_index = {}
@@ -52,7 +54,7 @@ def _arrange(node_tree, padding: typing.Tuple[float, float] = (50, 25)):
             output_count = len(list(filter(lambda i: i.enabled, node.outputs)))
             parent_props = [prop.identifier for base in type(node).__bases__ for prop in base.bl_rna.properties]
             properties_count = len([prop for prop in node.bl_rna.properties if prop.identifier not in parent_props])
-            unset_vector_count = len(list(filter(lambda i: i.enabled and i.type == 'VECTOR' and len(i.links) == 0, node.inputs)))
+            unset_vector_count = len(list(filter(lambda i: i.enabled and i.type == 'VECTOR' and node_input_link_count[i] == 0, node.inputs)))
             node_height = (
                 NODE_HEADER_HEIGHT \
                 + (output_count * NODE_LINK_HEIGHT) \

--- a/api/arrange.py
+++ b/api/arrange.py
@@ -29,7 +29,7 @@ def _arrange(node_tree, padding: typing.Tuple[float, float] = (50, 25)):
 
     column_index = {}
     for node in reversed(sorted_nodes):
-        column_index[node] = max([ column_index[node] for node in graph[node] ], default=-1) + 1
+        column_index[node] = max([ column_index[adj_node] for adj_node in graph[node] ], default=-1) + 1
         if column_index[node] == len(columns):
             columns.append([node])
         else:

--- a/api/arrange.py
+++ b/api/arrange.py
@@ -1,6 +1,6 @@
 import bpy
 import typing
-from collections import deque
+from collections import deque, Counter
 
 def _arrange(node_tree, padding: typing.Tuple[float, float] = (50, 25)):
     # Organize the nodes into columns based on their links.
@@ -23,7 +23,7 @@ def _arrange(node_tree, padding: typing.Tuple[float, float] = (50, 25)):
         return topo_order
     
     graph = { node:set() for node in node_tree.nodes }
-    node_input_link_count = { i:0  for node in node_tree.nodes for i in node.inputs }
+    node_input_link_count = Counter()
     for link in node_tree.links:
         graph[link.from_node].add(link.to_node)
         node_input_link_count[link.to_socket] += 1


### PR DESCRIPTION
As the number of nodes and links increase, some performance issues become apparent in the ~100 to ~1000 range.

The performance particularly suffers when the number of links to a join geometry node increases.
Both tree 1 and tree 2 here have ~1000 nodes and ~1000 links but tree 2 has more links going into a single join geometry node.

```python
@tree
def test(): 
    N,K = 100, 8 # Tree 1
    #N,K = 10, 98 # Tree 2
    mesh = cube().mesh
    for i in range(N): 
        meshes = []     
        for j in range(K):
            meshes.append(cube().mesh)
        combined=join_geometry(geometry=meshes)
        mesh = join_geometry(geometry=[combined,mesh])
    return mesh
```
### Time to Generate Topo Sorted Columns of Nodes
| Algorithm:        |  Tree 1          | Tree 2 |
| ------------- |:-------------:| -----:|
| Before      | 25s | 228s |
| After      | < 0.1s     |  < 0.1s |

The performance enhancement is mostly due to avoiding repetitive use of the 'links' property of the NodeSocket class which is [currently](https://github.com/carson-katri/geometry-script/blob/e3befbefc94ba03f0f5033bcbd32869a72734bcd/api/arrange.py#L8-L14) being invoked for every node input of each node. This is problematic since the [links property](https://github.com/blender/blender/blob/878f71061b8eb30ef3513d302b8b9bbcecc0c5ba/scripts/modules/bpy_types.py#L1210) iterates through all the links of the nodetree. In the new implementation, direct iteration over the links occurs only [once ](https://github.com/alphadito/geometry-script/blob/1c641c7f4b8c3db188814f8ee250742b8e4ab90a/api/arrange.py#L26) to create a graph structure which is then used to topologically sort the nodes.

Other bottlenecks occur at the >1k nodes range.
For example, both running the [update](https://github.com/carson-katri/geometry-script/blob/e3befbefc94ba03f0f5033bcbd32869a72734bcd/api/arrange.py#L44) function on a node and setting its [location ](https://github.com/carson-katri/geometry-script/blob/e3befbefc94ba03f0f5033bcbd32869a72734bcd/api/arrange.py#L59)
each take about 1.5 seconds on a node tree with 1k nodes but 20 seconds each with 3k nodes (some very weird super quadratic complexity going on here).

I'm not really sure if `node.update()` is required though. I've tried commenting it out and everything seemed fine  ¯\\\_(ツ)_/¯


