### PR TITLE
Input options

### DIFF
--- a/api/static/input_options.py
+++ b/api/static/input_options.py
@@ -1,32 +1,56 @@
 import enum
 
-class SubtypeInt(enum.Enum):
-    NONE = 'None'
-    PERCENTAGE = 'Percentage'
-    FACTOR = 'Factor'
-
-class SubtypeFloat(enum.Enum):
-    NONE = 'None'
-    PERCENTAGE = 'Percentage'
-    FACTOR = 'Factor'
-    ANGLE = 'Angle'
-    TIME = 'Time (Scene Relative)'
-    TIME_ABSOLUTE = 'Time (Absolute)'
-    DISTANCE = 'Distance'
-
-class InputOptions:
-    """Input options parent class"""
-
-class IntOptions(InputOptions):
+class Subtype(enum.Enum):
     """
-    Title.
+    If using subtype option, your geometry script must run in the active workspace containing the Geometry Node Editor 
+    """
+
+class SubtypeInt(Subtype):
+    NONE = 'NONE'
+    PERCENTAGE = 'PERCENTAGE'
+    FACTOR = 'FACTOR'
+
+class SubtypeFloat(Subtype):
+    NONE = 'NONE'
+    PERCENTAGE = 'PERCENTAGE'
+    FACTOR = 'FACTOR'
+    ANGLE = 'ANGLE'
+    TIME = 'TIME'
+    TIME_ABSOLUTE = 'TIME_ABSOLUTE'
+    DISTANCE = 'DISTANCE'
+
+class SubtypeVector(Subtype):
+    NONE = 'NONE'
+    TRANSLATION = 'TRANSLATION'
+    VELOCITY = 'VELOCITY'
+    ACCELERATION = 'ACCELERATION'
+    EULER = 'EULER'
+    XYZ = 'XYZ'
+
+
+class _InputOptions:
+    """Input options parent class."""
+    def __init__(self, default, min, max, subtype, name, tooltip, hide_in_modifier):
+        self.default_value = default 
+        self.min_value = min   
+        self.max_value = max
+        self.bl_subtype_label = subtype.value if subtype != None else None
+        self.name = name
+        self.description = tooltip
+        self.hide_in_modifier = hide_in_modifier
+
+
+class IntOptions(_InputOptions):
+    """
+    Integer input options.
     
-    Example descriptions:
+    Usage example:
     ```python
     my_int: Float = IntOptions(
         default=3,
         min=1,
-        max=5
+        max=5,
+        subtype=SubtypeInt.DISTANCE
     ),
     ```
     """
@@ -43,24 +67,20 @@ class IntOptions(InputOptions):
         tooltip: str = None,
         hide_in_modifier: bool = None,
     ):
-        self.default_value = default 
-        self.min_value = min   
-        self.max_value = max
-        self.bl_subtype_label = subtype.value if subtype != None else None
-        self.name = name
-        self.description = tooltip
-        self.hide_in_modifier = hide_in_modifier
+        super().__init__(default, min, max, subtype, name, tooltip, hide_in_modifier)
 
-class FloatOptions(InputOptions):
+
+class FloatOptions(_InputOptions):
     """
-    Title.
+    Float input options.
     
-    Example descriptions:
+    Usage example:
     ```python
     my_float: Float = FloatOptions(
         default=1.5,
         min=-0.5,
-        max=2.5
+        max=2.5,
+        subtype=SubtypeFloat.DISTANCE
     ),
     ```
     """
@@ -77,10 +97,36 @@ class FloatOptions(InputOptions):
         tooltip: str = None,
         hide_in_modifier: bool = None,
     ):
-        self.default_value = default 
-        self.min_value = min   
-        self.max_value = max
-        self.bl_subtype_label = subtype.value if subtype != None else None
-        self.name = name
-        self.description = tooltip
-        self.hide_in_modifier = hide_in_modifier
+        super().__init__(default, min, max, subtype, name, tooltip, hide_in_modifier)
+
+
+class VectorOptions(_InputOptions):
+    """
+    Vector input options.
+    
+    Usage example:
+    ```python
+    my_float: Vector = VectorOptions(
+        default_x=0.5,
+        default_y=1.0,
+        default_z=1.5,
+        min=-0.5,
+        max=2.5,
+        subtype=SubtypeVecotr.TRANSLATION
+    ),
+    ```
+    """
+
+    def __init__(
+        self,
+        default_x: float | None = None,
+        default_y: float | None = None,
+        default_z: float | None = None,
+        min: float | None = None,
+        max: float | None = None,
+        subtype: SubtypeVector | None = None,
+        name: str | None = None,
+        tooltip: str = None,
+        hide_in_modifier: bool = None,
+    ):
+        super().__init__((default_x, default_y, default_z), min, max, subtype, name, tooltip, hide_in_modifier)

--- a/api/static/input_options.py
+++ b/api/static/input_options.py
@@ -1,0 +1,62 @@
+import enum
+
+class SubtypeInt(enum.Enum):
+    NONE = 'None'
+    PERCENTAGE = 'Percentage'
+    FACTOR = 'Factor'
+
+class SubtypeFloat(enum.Enum):
+    NONE = 'None'
+    PERCENTAGE = 'Percentage'
+    FACTOR = 'Factor'
+    ANGLE = 'Angle'
+    TIME = 'Time (Scene Relative)'
+    TIME_ABSOLUTE = 'Time (Absolute)'
+    DISTANCE = 'Distance'
+
+class InputOptions:
+    """Input options parent class"""
+
+class IntOptions(InputOptions):
+    MAX = 2147483647
+    MIN = -MAX -1
+    
+    def __init__(
+        self,
+        default: int | None = None,
+        min: int | None = None,
+        max: int | None = None,
+        subtype: SubtypeInt | None = None,
+        name: str | None = None,
+        tooltip: str = None,
+        hide_in_modifier: bool = None,
+    ):
+        self.default_value = default 
+        self.min_value = min   
+        self.max_value = max
+        self.bl_subtype_label = subtype.value if subtype != None else None
+        self.name = name
+        self.description = tooltip
+        self.hide_in_modifier = hide_in_modifier
+
+class FloatOptions(InputOptions):
+    MAX = float('inf')
+    MIN = float('-inf')
+    
+    def __init__(
+        self,
+        default: float | None = None,
+        min: float | None = None,
+        max: float | None = None,
+        subtype: SubtypeFloat | None = None,
+        name: str | None = None,
+        tooltip: str = None,
+        hide_in_modifier: bool = None,
+    ):
+        self.default_value = default 
+        self.min_value = min   
+        self.max_value = max
+        self.bl_subtype_label = subtype.value if subtype != None else None
+        self.name = name
+        self.description = tooltip
+        self.hide_in_modifier = hide_in_modifier

--- a/api/static/input_options.py
+++ b/api/static/input_options.py
@@ -18,6 +18,18 @@ class InputOptions:
     """Input options parent class"""
 
 class IntOptions(InputOptions):
+    """
+    Title.
+    
+    Example descriptions:
+    ```python
+    my_int: Float = IntOptions(
+        default=3,
+        min=1,
+        max=5
+    ),
+    ```
+    """
     MAX = 2147483647
     MIN = -MAX -1
     
@@ -40,6 +52,18 @@ class IntOptions(InputOptions):
         self.hide_in_modifier = hide_in_modifier
 
 class FloatOptions(InputOptions):
+    """
+    Title.
+    
+    Example descriptions:
+    ```python
+    my_float: Float = FloatOptions(
+        default=1.5,
+        min=-0.5,
+        max=2.5
+    ),
+    ```
+    """
     MAX = float('inf')
     MIN = float('-inf')
     

--- a/api/tree.py
+++ b/api/tree.py
@@ -117,6 +117,10 @@ def tree(name):
                     node_input = node_group.inputs.new(arg[1][0].socket_type, input_name)
             if arg[1][1] != inspect.Parameter.empty:
                 node_input.default_value = arg[1][1]
+            if hasattr(arg[1][0], 'min_value'):
+                node_input.min_value = arg[1][0].min_value
+            if hasattr(arg[1][0], 'max_value'):
+                node_input.max_value = arg[1][0].max_value
             if arg[1][2] is not None:
                 if arg[1][2] not in builder_inputs:
                     builder_inputs[arg[1][2]] = signature.parameters[arg[1][2]].annotation()

--- a/api/tree.py
+++ b/api/tree.py
@@ -125,7 +125,7 @@ def tree(name):
                 input_options.process(node_input.type)
                 node_input.min_value = input_options.min_value
                 node_input.max_value = input_options.max_value
-                node_input.bl_subtype_label = input_options.bl_subtype_label # DOES NOT WORK. Do e nee to change a UI property like this: ui_property(object, "property-name", expand=False, text="New Label")
+                # node_input.bl_subtype_label = input_options.bl_subtype_label # DOES NOT WORK. Do e nee to change a UI property like this: ui_property(object, "property-name", expand=False, text="New Label")
                 node_input.description = input_options.description
                 node_input.hide_in_modifier = input_options.hide_in_modifier
             else:

--- a/api/tree.py
+++ b/api/tree.py
@@ -106,7 +106,10 @@ def tree(name):
 
         node_inputs = get_node_inputs(node_group)
         for i, arg in enumerate(inputs.items()):
-            input_name = arg[0].replace('_', ' ').title()
+            if hasattr(arg[1][0], 'input_options') and arg[1][0].input_options.name != None:
+                input_name = arg[1][0].input_options.name
+            else:
+                input_name = arg[0].replace('_', ' ').title()
             if len(node_inputs) > i:
                 node_inputs[i].name = input_name
                 node_input = node_inputs[i]
@@ -117,10 +120,25 @@ def tree(name):
                     node_input = node_group.inputs.new(arg[1][0].socket_type, input_name)
             if arg[1][1] != inspect.Parameter.empty:
                 node_input.default_value = arg[1][1]
-            if hasattr(arg[1][0], 'min_value'):
-                node_input.min_value = arg[1][0].min_value
-            if hasattr(arg[1][0], 'max_value'):
-                node_input.max_value = arg[1][0].max_value
+            if hasattr(arg[1][0], 'input_options'):
+                input_options = arg[1][0].input_options
+                input_options.process(node_input.type)
+                node_input.min_value = input_options.min_value
+                node_input.max_value = input_options.max_value
+                node_input.bl_subtype_label = input_options.bl_subtype_label # DOES NOT WORK. Do e nee to change a UI property like this: ui_property(object, "property-name", expand=False, text="New Label")
+                node_input.description = input_options.description
+                node_input.hide_in_modifier = input_options.hide_in_modifier
+            else:
+                # reset all options to defaults ???????
+                pass
+                # input_options = InputOptions() 
+                # input_options.process(node_input.type) 
+                # node_input.min_value = input_options.min_value
+                # node_input.max_value = input_options.max_value
+                # node_input.bl_subtype_label = input_options.bl_subtype_label
+                # node_input.description = input_options.description
+                # node_input.hide_in_modifier = input_options.hide_in_modifier
+
             if arg[1][2] is not None:
                 if arg[1][2] not in builder_inputs:
                     builder_inputs[arg[1][2]] = signature.parameters[arg[1][2]].annotation()

--- a/api/tree.py
+++ b/api/tree.py
@@ -157,7 +157,7 @@ def tree(name):
                         node_input.hide_in_modifier = arg[1][1].hide_in_modifier
                 else:
                     node_input.default_value = arg[1][1]
-                    if isinstance(arg[1][1], int):
+                    if type(arg[1][1]) == type(0):  # because: isinstance(True, int) == True
                         node_input.min_value = IntOptions.MIN
                         node_input.max_value = IntOptions.MAX
                     elif isinstance(arg[1][1], float):

--- a/api/types.py
+++ b/api/types.py
@@ -6,6 +6,9 @@ from .state import State
 from .static.sample_mode import SampleMode
 import geometry_script
 
+INT_MIN = -2147483648
+INT_MAX = 2147483647
+
 def map_case_name(i):
     return ('_' if not i.identifier[0].isalpha() else '') + i.identifier.replace(' ', '_').upper()
 
@@ -32,11 +35,23 @@ def socket_class_to_data_type(socket_class_name):
 # The base class all exposed socket types conform to.
 class _TypeMeta(type):
     def __getitem__(self, args):
-        for s in filter(lambda x: isinstance(x, slice), args):
-            if (isinstance(s.start, float) or isinstance(s.start, int)) and (isinstance(s.stop, float) or isinstance(s.stop, int)):
-                print(f"minmax: ({s.start}, {s.stop})")
-            elif isinstance(s.start, str):
-                print(f"{s.start} = {s.stop}")
+        if isinstance(args, int):
+            setattr(self, 'min_value', args)
+            setattr(self, 'max_value', INT_MAX)
+        elif isinstance(args, float):
+            setattr(self, 'min_value', args)
+            setattr(self, 'max_value', float('inf'))
+        elif isinstance(args, tuple):
+            if isinstance(args[0], int) or isinstance(args[0], float):
+                setattr(self, 'min_value', args[0])
+            if len(args) > 1 and (isinstance(args[1], int) or isinstance(args[1], float)):
+                setattr(self, 'max_value', args[1])
+        elif isinstance(args, slice):
+            if isinstance(args.start, int) or isinstance(args.start, float):
+                setattr(self, 'min_value', args.start)
+            if isinstance(args.stop, int) or isinstance(args.stop, float):
+                setattr(self, 'max_value', args.stop)
+
         return self
 
 class Type(metaclass=_TypeMeta):

--- a/api/types.py
+++ b/api/types.py
@@ -6,71 +6,6 @@ from .state import State
 from .static.sample_mode import SampleMode
 import geometry_script
 
-INT_MAX = 2147483647
-INT_MIN = -INT_MAX -1 
-
-class SubtypeInt(enum.Enum):
-    NONE = 'None'
-    PERCENTAGE = 'Percentage'
-    FACTOR = 'Factor'
-
-class SubtypeFloat(enum.Enum):
-    NONE = 'None'
-    PERCENTAGE = 'Percentage'
-    FACTOR = 'Factor'
-    ANGLE = 'Angle'
-    TIME = 'Time (Scene Relative)'
-    TIME_ABSOLUTE = 'Time (Absolute)'
-    DISTANCE = 'Distance'
-
-class InputOptions:
-    min_value: int | float
-    max_value: int | float
-    bl_subtype_label: str
-    name: str
-    description: str
-    hide_in_modifier: bool
-
-    def __init__(
-        self,
-        min: int | float | None = None,
-        max: int | float | None = None,
-        subtype: SubtypeInt | SubtypeFloat | None = None,
-        name: str | None = None,
-        tooltip: str = '',
-        hide_in_modifier: bool = False
-    ):
-        self.min_value = min   
-        self.max_value = max
-        self.bl_subtype_label = subtype.value if subtype != None else None
-        self.name = name
-        self.description = tooltip
-        self.hide_in_modifier = hide_in_modifier
-
-    def process(self, node_input_type: str):
-        if node_input_type == 'INT':
-            if self.min_value != None and self.max_value == None:
-                self.max_value = INT_MAX
-            if self.max_value != None and self.min_value == None:
-                self.min_value = INT_MIN
-            if isinstance(self.min_value, float):
-                self.min_value = int(self.min_value)
-            if isinstance(self.max_value, float):
-                self.max_value = int(self.max_value)
-            if self.bl_subtype_label == None:
-                self.bl_subtype_label = SubtypeInt.NONE
-        elif node_input_type == 'VALUE':
-            if self.min_value != None and self.max_value == None:
-                self.max_value = float('inf')
-            if self.max_value != None and self.min_value == None:
-                self.min_value = float('-inf')
-            if isinstance(self.min_value, int):
-                self.min_value = float(self.min_value)
-            if isinstance(self.max_value, int):
-                self.max_value = float(self.max_value)
-            if self.bl_subtype_label == None:
-                self.bl_subtype_label = SubtypeFloat.NONE
-
 def map_case_name(i):
     return ('_' if not i.identifier[0].isalpha() else '') + i.identifier.replace(' ', '_').upper()
 
@@ -94,37 +29,7 @@ def socket_class_to_data_type(socket_class_name):
         case _:
             return socket_class_name
 
-# The base class all exposed socket types conform to.
-class _TypeMeta(type):
-    def __getitem__(self, args):
-        input_options = None
-        if isinstance(args, int) or isinstance(args, float):
-            input_options = InputOptions(min=args)
-        elif isinstance(args, tuple):
-            tuple_args = {}
-            if isinstance(args[0], int) or isinstance(args[0], float):
-                tuple_args['min'] = args[0]
-            if len(args) > 1 and (isinstance(args[1], int) or isinstance(args[1], float)):
-                tuple_args['max'] = args[1]
-            if len(tuple_args) > 0:
-                input_options = InputOptions(**tuple_args)
-        elif isinstance(args, slice):
-            slice_args = {}
-            if isinstance(args.start, int) or isinstance(args.start, float):
-                slice_args['min'] = args.start
-            if isinstance(args.stop, int) or isinstance(args.stop, float):
-                slice_args['max'] = args.stop
-            if len(slice_args) > 0:
-                input_options = InputOptions(**slice_args)
-        elif isinstance(args, InputOptions):
-            input_options = args
-
-        if input_options != None:
-            setattr(self, 'input_options', input_options)
-
-        return self
-
-class Type(metaclass=_TypeMeta):
+class Type:
     socket_type: str
 
     def __init__(self, socket: bpy.types.NodeSocket = None, value = None):


### PR DESCRIPTION
Currently Geometry Scripts supports default values for the args in the tree function. This PR allows to use alternatively an `InputOption` based object instead, which supports all relevant options from the **Geometry Node Editor / Group / Inputs** options panel. Currently supported are: `IntOptions`, `FloatOptions` and `VectorOptions`.

Example usage:
```python
def test_all_float_options(value: Float = FloatOptions(
    default=3.0,
    min=0.0,
    max=5.0,
    subtype=SubtypeFloat.DISTANCE,
    name='My custom name',
    tooltip='My description'
): pass

def test_some_int_options(value: Int = IntOptions(
    default=3,
    min=0,
    max=5,
    subtype=SubtypeInt.PERCENTAGE,
): pass

def test_some_vector_options(value: Vector = VectorOptions(
    default_x=0.5,      #  see
    default_y=1.0,      #  explanation
    default_z=1.5,      #  below
    min=0.3,
    max=8.5,
    subtype=SubtypeVector.TRANSLATION
): pass
```
For the vector default value, it was not possible to use `tuple` or `[]`, because a typing definition like:
```python
default: {float, float, float} | None = None
```
 is not supported by the Python typing system.

The `subtype` option I only managed to set by using an operator (which needs a specific context). That means running the geometry script containing subtype options has to be done in the same blender workspace as the Geometry Node Editor. That means running a script in default Blender setup with Text Editor in the scripting workspace, any `subtype` options will be silently ignored.

TODO:
- if PR gets accepted, add some documentation
- Extend the Geometry Script addon, so scripts can be run from the Geometry Nodes Editor (to avoid the possible subtype issue mentioned above). This probably makes most sense for external editing and maybe we could even go as far as integrating some ideas from the vscode-blender extension to facilitate multi-file projects with automatic reload/re-import 