### PR TITLE
fix typo in example repeat_grid.py

### DIFF
--- a/examples/Repeat Grid.py
+++ b/examples/Repeat Grid.py
@@ -5,5 +5,5 @@ def repeat_grid(geometry: Geometry, width: Int, height: Int):
     g = grid(
         size_x=width, size_y=height,
         vertices_x=width, vertices_y=height
-    ).mesh_to_points()
+    ).mesh.mesh_to_points()
     return g.instance_on_points(instance=geometry)


### PR DESCRIPTION
Corrects the method chain so that mesh_to_points is called on the mesh object.
From: .mesh_to_points()
To: .mesh.mesh_to_points() 
