### PR TITLE
Fix Repeat Grid example: add proper spacing to prevent overlap

### DIFF
--- a/examples/Repeat Grid.py
+++ b/examples/Repeat Grid.py
@@ -1,9 +1,20 @@
 from geometry_script import *
 
 @tree("Repeat Grid")
-def repeat_grid(geometry: Geometry, width: Int, height: Int):
+def repeat_grid(geometry: Geometry, columns: Int, rows: Int):
+   # measure your geometry’s bounds
+    bbox = geometry.bounding_box()
+    span_x = bbox.max.x - bbox.min.x
+    span_y = bbox.max.y - bbox.min.y
+
+    # total grid size = N * object size
+    total_x = columns * span_x
+    total_y = rows    * span_y
+
+    # one extra vertex gives N cells
     g = grid(
-        size_x=width, size_y=height,
-        vertices_x=width, vertices_y=height
-    ).mesh_to_points()
+        size_x=total_x, size_y=total_y,
+        vertices_x=columns+1, vertices_y=rows+1
+    ).mesh.mesh_to_points()
+
     return g.instance_on_points(instance=geometry)

--- a/examples/Repeat Grid.py
+++ b/examples/Repeat Grid.py
@@ -1,20 +1,26 @@
 from geometry_script import *
 
 @tree("Repeat Grid")
-def repeat_grid(geometry: Geometry, columns: Int, rows: Int):
+def repeat_grid(
+    geometry: Geometry,
+    columns: Int,
+    rows: Int,
+    spacing_x: Float = 0.0,
+    spacing_y: Float = 0.0
+):
    # measure your geometry’s bounds
     bbox = geometry.bounding_box()
     span_x = bbox.max.x - bbox.min.x
     span_y = bbox.max.y - bbox.min.y
 
     # total grid size = N * object size
-    total_x = columns * span_x
-    total_y = rows    * span_y
+    total_x = columns * span_x + (columns - 1) * spacing_x
+    total_y = rows    * span_y + (rows - 1) * spacing_y
 
     # one extra vertex gives N cells
     g = grid(
         size_x=total_x, size_y=total_y,
-        vertices_x=columns+1, vertices_y=rows+1
+        vertices_x=columns + 1, vertices_y=rows + 1
     ).mesh.mesh_to_points()
 
     return g.instance_on_points(instance=geometry)


### PR DESCRIPTION
… calculation

- Rename parameters from width/height to columns/rows for clarity
- Implement proper bounding box calculation for geometry spacing
- Fix grid vertex calculation (use N+1 vertices for N cells)
- Add explanatory comments for grid sizing logic
- Fix method chaining for mesh_to_points