### PR TITLE
Fix nested @tree group references on Blender 4+

### DIFF
--- a/api/tree.py
+++ b/api/tree.py
@@ -163,12 +163,21 @@ def tree(name):
         # This lets @trees be used in other @trees via simple function calls.
         def group_reference(*args, **kwargs):
             if IS_BLENDER_4:
-                result = geometrynodegroup(node_tree=node_group, *args, **kwargs)
+                result = State.current_node_tree.nodes.new('GeometryNodeGroup')
+                result.node_tree = node_group
+                enabled_inputs = [node_input for node_input in result.inputs if node_input.enabled]
+                for value, node_input in zip(args, enabled_inputs):
+                    set_or_create_link(value, node_input)
+                for node_input in enabled_inputs[len(args):]:
+                    argname = node_input.name.lower().replace(' ', '_')
+                    if argname in kwargs:
+                        set_or_create_link(kwargs[argname], node_input)
             else:
                 result = group(node_tree=node_group, *args, **kwargs)
             group_outputs = []
-            for group_output in result._socket.node.outputs:
-                group_outputs.append(Type(group_output))
+            for group_output in result.outputs:
+                if group_output.enabled:
+                    group_outputs.append(Type(group_output))
             if len(group_outputs) == 1:
                 return group_outputs[0]
             else:


### PR DESCRIPTION
Geometry Script's `@tree` decorator returns a function intended to create nested node-group nodes when called inside another `@tree`. On Blender 4/5, that path currently calls a generated `geometrynodegroup(...)` symbol that is not available, so nested tree reuse fails.

This patch creates `GeometryNodeGroup` directly for Blender 4+, assigns the referenced node tree, wires positional and keyword inputs through the existing `set_or_create_link` helper, and returns `Type` wrappers for enabled outputs.

Verified in Blender 5.1.1 through VibeGeometry's translated graph corpus: a circle graph calls a helper `@tree` twice as nested groups, generates `GeometryNodeGroup` nodes, and matches the source graph's evaluated geometry.